### PR TITLE
fix: DecoderBlock no arg named use_skip_conn

### DIFF
--- a/models.py
+++ b/models.py
@@ -110,6 +110,8 @@ class DecoderBlock(nn.Module):
         residual: bool = True,
         use_skip_conn: bool = True,
     ):
+        self.use_skip_conn = use_skip_conn
+
         super().__init__()
         self.upsample = nn.ConvTranspose2d(
             in_channels,


### PR DESCRIPTION
added one line adding use_skip_conn inside init as arg, forward pass was referncing on it but it did not exist until now